### PR TITLE
Warn about sensitive step properties on import

### DIFF
--- a/source/OctopusTools/Importers/ProjectImporter.cs
+++ b/source/OctopusTools/Importers/ProjectImporter.cs
@@ -288,6 +288,12 @@ namespace OctopusTools.Importers
                     }
                     action.Environments.Clear();
                     action.Environments.AddRange(newEnvironmentIds);
+
+                    // Display warning for sensitive properties in this action
+                    if (action.SensitiveProperties.Count > 0)
+                    {
+                        Log.WarnFormat("Process step '{0}' contains sensitive settings that will be cleared, once the import has completed you will need to check this step in the UI and update required settings", action.Name);
+                    }
                 }
             }
             existingDeploymentProcess.Steps.Clear();


### PR DESCRIPTION
We already have warnings when importing sensitive variables so the
user knows that the actual values were not imported.  We need
similar warnings for deployment process steps because it's easy to
miss sensitive settings such as a custom service user password.

Unlike variables, the UI only shows a descriptive label for the
step properties, so the actual property name would not be useful
in the log message.  There are also properties that may not be
used depending on the values of other related properties, so they
don't really need to be set.  Instead, just log a general warning
for each step that contains sensitive properties so that the
user knows to check those steps after the import is complete.