### PR TITLE
Prerelease fallback

### DIFF
--- a/source/OctopusTools.Tests/Commands/CreateReleaseCommandFixture.cs
+++ b/source/OctopusTools.Tests/Commands/CreateReleaseCommandFixture.cs
@@ -130,6 +130,39 @@ namespace OctopusTools.Tests.Commands
             Repository.Releases.Received().Create(Arg.Is<ReleaseResource>(r => r.SelectedPackages.Any(p => p.Version.Equals("1.0.0-Dev"))));
         }
 
+        [Test]
+        public void when_prerelease_specified_and_fallback_mode_latest_should_choose_latest()
+        {
+            command.ProjectName = "ProjectA";
+            command.VersionPrerelease = "Dev";
+            command.PrereleaseFallbackMode = PrereleaseFallbackMode.Latest;
+            Repository.Client.Get<List<PackageResource>>("feed1search", Arg.Any<object>()).Returns(new List<PackageResource>()
+            {
+                new PackageResource(){NuGetPackageId = "Package1", Version = "1.0.0"},
+            });
+
+            Repository.Releases.Create(Arg.Any<ReleaseResource>()).Returns(new ReleaseResource());
+            command.Execute(CommandLineArgs.ToArray());
+
+            Repository.Releases.Received().Create(Arg.Is<ReleaseResource>(r => r.SelectedPackages.Any(p => p.Version.Equals("1.0.0"))));
+        }
+
+        [Test]
+        public void when_prerelease_specified_and_fallback_mode_fail_should_throw_exception()
+        {
+            command.ProjectName = "ProjectA";
+            command.VersionPrerelease = "Dev";
+            command.PrereleaseFallbackMode = PrereleaseFallbackMode.Fail;
+
+            Repository.Client.Get<List<PackageResource>>("feed1search", Arg.Any<object>()).Returns(new List<PackageResource>()
+            {
+                new PackageResource(){NuGetPackageId = "Package1", Version = "1.0.0"},
+            });
+
+            Repository.Releases.Create(Arg.Any<ReleaseResource>()).Returns(new ReleaseResource());
+
+            Assert.Throws<CommandException>(() => command.Execute(CommandLineArgs.ToArray()));
+        }
 
     }
 }

--- a/source/OctopusTools.Tests/Commands/CreateReleaseCommandFixture.cs
+++ b/source/OctopusTools.Tests/Commands/CreateReleaseCommandFixture.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Client.Model;
+using OctopusTools.Commands;
+using OctopusTools.Infrastructure;
+
+namespace OctopusTools.Tests.Commands
+{
+    [TestFixture]
+    public class CreateReleaseCommandFixture : ApiCommandFixtureBase
+    {
+
+        CreateReleaseCommand command;
+
+        [SetUp]
+        public void Setup()
+        {
+            command = new CreateReleaseCommand(RepositoryFactory, Log, new PackageVersionResolver(Log));
+
+            //fake project
+            Repository.Projects.FindByName("ProjectA").Returns(info => new ProjectResource("projecta", "ProjectA", "a") {DeploymentProcessId = "deploymentprocess1"});
+
+            //fake deployment process
+            Repository.DeploymentProcesses.Get("deploymentprocess1").Returns(new DeploymentProcessResource()
+            {
+                Links = new LinkCollection() { {"Template", "footemplate"} }
+            });
+
+            //fake template
+            Repository.DeploymentProcesses.GetTemplate(Arg.Any<DeploymentProcessResource>()).Returns(new ReleaseTemplateResource()
+            {
+                NextVersionIncrement = "1.0",
+                Packages = new List<ReleaseTemplatePackage>()
+                {
+                    new ReleaseTemplatePackage(){NuGetFeedId = "feed1", IsResolvable = true, NuGetPackageId = "Package1", StepName = "StepA"}
+                }
+            });
+
+            //fake feed
+            Repository.Feeds.Get("feed1").Returns(new FeedResource()
+            {
+                FeedUri = "foo://",
+                Links = new LinkCollection()
+                {
+                    {"VersionsTemplate", "feed1versions"},
+                    {"SearchTemplate", "feed1search"}
+                }
+            });
+
+
+        }
+
+        [Test]
+        public void when_project_not_exists_should_throw_exception()
+        {
+            command.ProjectName = "ProjectB";
+            Assert.Throws<CommandException>(()=>command.Execute(CommandLineArgs.ToArray()), "Could not find a project named: ProjectB");
+        }
+
+        [Test]
+        [ExpectedException(typeof(CommandException))]
+        public void when_no_versions_should_log_error()
+        {
+            command.ProjectName = "ProjectA";
+            Repository.Client.Get<List<PackageResource>>("feed1versions", Arg.Any<object>()).Returns(new List<PackageResource>());
+            command.Execute(CommandLineArgs.ToArray());
+
+            Log.Received().ErrorFormat("Could not find any packages with ID '{0}' in the feed '{1}'", "Package1", "foo://");
+
+        }
+
+        [Test]
+        public void when_no_versions_should_throw_exception()
+        {
+            command.ProjectName = "ProjectA";
+            Repository.Client.Get<List<PackageResource>>("feed1versions", Arg.Any<object>()).Returns(new List<PackageResource>());
+
+            Assert.Throws<CommandException>(()=>command.Execute(CommandLineArgs.ToArray()));
+        }
+
+        [Test]
+        public void when_version_exists_should_create_release()
+        {
+            command.ProjectName = "ProjectA";
+            Repository.Client.Get<List<PackageResource>>("feed1versions", Arg.Any<object>()).Returns(new List<PackageResource>()
+            {
+                new PackageResource(){NuGetPackageId = "Package1", Version = "1.0.0"},
+            });
+            Repository.Releases.Create(Arg.Any<ReleaseResource>()).Returns(new ReleaseResource());
+            command.Execute(CommandLineArgs.ToArray());
+
+            Repository.Releases.Received().Create(Arg.Any<ReleaseResource>());
+
+        }
+
+        [Test]
+        public void when_version_exists_should_include_in_release()
+        {
+            command.ProjectName = "ProjectA";
+            Repository.Client.Get<List<PackageResource>>("feed1versions", Arg.Any<object>()).Returns(new List<PackageResource>()
+            {
+                new PackageResource(){NuGetPackageId = "Package1", Version = "1.0.0"},
+            });
+
+            Repository.Releases.Create(Arg.Any<ReleaseResource>()).Returns(new ReleaseResource());
+            command.Execute(CommandLineArgs.ToArray());
+
+            Repository.Releases.Received().Create(Arg.Is<ReleaseResource>(r=>r.SelectedPackages.Any(p=>p.Version.Equals("1.0.0"))));
+
+        }
+        
+        [Test]
+        public void when_prerelease_version_specified_should_use_that()
+        {
+            command.ProjectName = "ProjectA";
+            command.VersionPrerelease = "Dev";
+            Repository.Client.Get<List<PackageResource>>("feed1search", Arg.Any<object>()).Returns(new List<PackageResource>()
+            {
+                new PackageResource(){NuGetPackageId = "Package1", Version = "1.0.0"},
+                new PackageResource(){NuGetPackageId = "Package1", Version = "1.0.0-Dev"},
+            });
+
+            Repository.Releases.Create(Arg.Any<ReleaseResource>()).Returns(new ReleaseResource());
+            command.Execute(CommandLineArgs.ToArray());
+
+            Repository.Releases.Received().Create(Arg.Is<ReleaseResource>(r => r.SelectedPackages.Any(p => p.Version.Equals("1.0.0-Dev"))));
+        }
+
+
+    }
+}

--- a/source/OctopusTools.Tests/OctopusTools.Tests.csproj
+++ b/source/OctopusTools.Tests/OctopusTools.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Client\OctopusSessionFactoryFixture.cs" />
     <Compile Include="Commands\ApiCommandFixture.cs" />
     <Compile Include="Commands\ApiCommandFixtureBase.cs" />
+    <Compile Include="Commands\CreateReleaseCommandFixture.cs" />
     <Compile Include="Commands\DummyApiCommand.cs" />
     <Compile Include="Commands\ListEnvironmentsCommandFixture.cs" />
     <Compile Include="Commands\ListProjectsCommandFixture.cs" />

--- a/source/OctopusTools/Commands/CreateReleaseCommand.cs
+++ b/source/OctopusTools/Commands/CreateReleaseCommand.cs
@@ -85,10 +85,10 @@ namespace OctopusTools.Commands
 
                     IEnumerable<PackageResource> packages; 
                     if (!string.IsNullOrWhiteSpace(VersionPrerelease))
-                        packages = Repository.Client.Get<List<PackageResource>>(feed.Link("SearchTemplate"), new { packageId = unresolved.PackageId, partialMatch = true }).Where(p => p.NuGetPackageId == unresolved.PackageId && p.Version.EndsWith("-" + VersionPrerelease));
+                        packages = Repository.Client.Get<List<PackageResource>>(feed.Link("SearchTemplate"), new { packageId = unresolved.PackageId }).Where(p => p.NuGetPackageId == unresolved.PackageId && p.Version.EndsWith("-" + VersionPrerelease));
                     else
                         packages = Repository.Client.Get<List<PackageResource>>(feed.Link("VersionsTemplate"), new { packageIds = new[] { unresolved.PackageId } });
-                     var version = packages.FirstOrDefault();
+                    var version = packages.FirstOrDefault();
 
                     if (version == null)
                     {

--- a/source/OctopusTools/Commands/PrereleaseFallbackMode.cs
+++ b/source/OctopusTools/Commands/PrereleaseFallbackMode.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace OctopusTools.Commands
+{
+    public enum PrereleaseFallbackMode
+    {
+        Latest,
+        Fail
+    }
+}

--- a/source/OctopusTools/OctopusTools.csproj
+++ b/source/OctopusTools/OctopusTools.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Commands\DumpDeploymentsCommand.cs" />
     <Compile Include="Commands\ListReleasesCommand.cs" />
     <Compile Include="Commands\OptionGroup.cs" />
+    <Compile Include="Commands\PrereleaseFallbackMode.cs" />
     <Compile Include="Repositories\ActionTemplateRepository.cs" />
     <Compile Include="Repositories\IActionTemplateRepository.cs" />
     <Compile Include="Util\LineSplitter.cs" />


### PR DESCRIPTION
This PR builds upon [PR 58](https://github.com/OctopusDeploy/Octopus-Tools/pull/58), so I'm not sure of the proper protocol for PRs like this.  If I need to re-submit for some reason, just LMK.

Anyway, this PR adds an extra parameter to the CreateRelease command that lets the command fall-back to the latest version of a package, if no pre-release version exists.

I found that I wanted this feature if I had a project that deploys multiple packages and I wanted to create a release for which only one of those packages was a pre-release version.