### PR TITLE
Octo.exe displays username that owns API key and suggests permissions issues

### DIFF
--- a/source/OctopusTools/Commands/ApiCommand.cs
+++ b/source/OctopusTools/Commands/ApiCommand.cs
@@ -34,8 +34,8 @@ namespace OctopusTools.Commands
             var options = optionGroups.For("Common options");
             options.Add("server=", "The base URL for your Octopus server - e.g., http://your-octopus/", v => serverBaseUrl = v);
             options.Add("apiKey=", "Your API key. Get this from the user profile page.", v => apiKey = v);
-            options.Add("username=", "[Optional] Username to use when authenticating with the server.", v => username = v);
-            options.Add("password=", "[Optional] Password to use when authenticating with the server.", v => password = v);
+            options.Add("user=", "[Optional] Username to use when authenticating with the server.", v => username = v);
+            options.Add("pass=", "[Optional] Password to use when authenticating with the server.", v => password = v);
             options.Add("configFile=", "[Optional] Text file of default values, with one 'key = value' per line.", v => ReadAdditionalInputsFromConfigurationFile(options, v));
             options.Add("debug", "[Optional] Enable debug logging", v => enableDebugging = true);
             options.Add("ignoreSslErrors", "[Optional] Set this flag if your Octopus server uses HTTPS but the certificate is not trusted on this machine. Any certificate errors will be ignored. WARNING: this option may create a security vulnerability.", v => ignoreSslErrors = true);

--- a/source/OctopusTools/Commands/ApiCommand.cs
+++ b/source/OctopusTools/Commands/ApiCommand.cs
@@ -20,10 +20,10 @@ namespace OctopusTools.Commands
         string apiKey;
         bool enableDebugging;
         bool ignoreSslErrors;
-        string pass;
+        string password;
         IOctopusRepository repository;
         string serverBaseUrl;
-        string user;
+        string username;
         readonly Options optionGroups = new Options();
 
         protected ApiCommand(IOctopusRepositoryFactory repositoryFactory, ILog log)
@@ -34,8 +34,8 @@ namespace OctopusTools.Commands
             var options = optionGroups.For("Common options");
             options.Add("server=", "The base URL for your Octopus server - e.g., http://your-octopus/", v => serverBaseUrl = v);
             options.Add("apiKey=", "Your API key. Get this from the user profile page.", v => apiKey = v);
-            options.Add("user=", "[Optional] Username to use when authenticating with the server.", v => user = v);
-            options.Add("pass=", "[Optional] Password to use when authenticating with the server.", v => pass = v);
+            options.Add("username=", "[Optional] Username to use when authenticating with the server.", v => username = v);
+            options.Add("password=", "[Optional] Password to use when authenticating with the server.", v => password = v);
             options.Add("configFile=", "[Optional] Text file of default values, with one 'key = value' per line.", v => ReadAdditionalInputsFromConfigurationFile(options, v));
             options.Add("debug", "[Optional] Enable debug logging", v => enableDebugging = true);
             options.Add("ignoreSslErrors", "[Optional] Set this flag if your Octopus server uses HTTPS but the certificate is not trusted on this machine. Any certificate errors will be ignored. WARNING: this option may create a security vulnerability.", v => ignoreSslErrors = true);
@@ -71,7 +71,7 @@ namespace OctopusTools.Commands
             if (string.IsNullOrWhiteSpace(apiKey))
                 throw new CommandException("Please specify your API key using --apiKey=ABCDEF123456789. Learn more at: https://github.com/OctopusDeploy/Octopus-Tools");
 
-            var credentials = ParseCredentials(user, pass);
+            var credentials = ParseCredentials(username, password);
 
             var endpoint = new OctopusServerEndpoint(serverBaseUrl, apiKey, credentials);
 
@@ -108,6 +108,9 @@ namespace OctopusTools.Commands
             log.Debug("Handshaking with Octopus server: " + serverBaseUrl);
             var root = repository.Client.RootDocument;
             log.Debug("Handshake successful. Octopus version: " + root.Version + "; API version: " + root.ApiVersion);
+
+            var user = repository.Users.GetCurrent();
+            log.DebugFormat("Logged in as: {0} <{1}>", user.DisplayName, user.EmailAddress);
 
             Execute();
         }

--- a/source/OctopusTools/Commands/ApiCommand.cs
+++ b/source/OctopusTools/Commands/ApiCommand.cs
@@ -110,7 +110,7 @@ namespace OctopusTools.Commands
             log.Debug("Handshake successful. Octopus version: " + root.Version + "; API version: " + root.ApiVersion);
 
             var user = repository.Users.GetCurrent();
-            log.DebugFormat("Logged in as: {0} <{1}>", user.DisplayName, user.EmailAddress);
+            log.DebugFormat("Authenticated as: {0} <{1}> {2}", user.DisplayName, user.EmailAddress, user.IsService ? "(a service account)":"");
 
             Execute();
         }

--- a/source/OctopusTools/Commands/CreateEnvironmentCommand.cs
+++ b/source/OctopusTools/Commands/CreateEnvironmentCommand.cs
@@ -13,7 +13,7 @@ namespace OctopusTools.Commands
         {
             var options = Options.For("Environment creation");
             options.Add("name=", "The name of the environment", v => EnvironmentName = v);
-            options.Add("ignoreIfExists", "If the project already exists, an error will be returned. Set this flag to ignore the error.", v => IgnoreIfExists = true);
+            options.Add("ignoreIfExists", "If the environment already exists, an error will be returned. Set this flag to ignore the error.", v => IgnoreIfExists = true);
         }
 
         public string EnvironmentName { get; set; }

--- a/source/OctopusTools/Commands/CreateReleaseCommand.cs
+++ b/source/OctopusTools/Commands/CreateReleaseCommand.cs
@@ -53,7 +53,7 @@ namespace OctopusTools.Commands
             Log.Debug("Finding project: " + ProjectName);
             var project = Repository.Projects.FindByName(ProjectName);
             if (project == null)
-                throw new CommandException("Could not find a project named: " + ProjectName);
+                throw new CouldNotFindException("a project named", ProjectName);
 
             Log.Debug("Finding deployment process for project: " + ProjectName);
             var deploymentProcess = Repository.DeploymentProcesses.Get(project.DeploymentProcessId);

--- a/source/OctopusTools/Commands/DeleteReleasesCommand.cs
+++ b/source/OctopusTools/Commands/DeleteReleasesCommand.cs
@@ -36,7 +36,7 @@ namespace OctopusTools.Commands
             Log.Debug("Finding project: " + ProjectName);
             var project = Repository.Projects.FindByName(ProjectName);
             if (project == null)
-                throw new CommandException("Could not find a project named: " + ProjectName);
+                throw new CouldNotFindException("a project named", ProjectName);
 
             Log.Debug("Finding releases for project...");
 

--- a/source/OctopusTools/Commands/DeployReleaseCommand.cs
+++ b/source/OctopusTools/Commands/DeployReleaseCommand.cs
@@ -37,7 +37,7 @@ namespace OctopusTools.Commands
             Log.Debug("Finding project: " + ProjectName);
             var project = Repository.Projects.FindByName(ProjectName);
             if (project == null)
-                throw new CommandException("Could not find a project named: " + ProjectName);
+                throw new CouldNotFindException("a project named", ProjectName);
 
             ReleaseResource releaseToPromote;
             if (string.Equals("latest", VersionNumber, StringComparison.CurrentCultureIgnoreCase))
@@ -47,7 +47,7 @@ namespace OctopusTools.Commands
 
                 if (releaseToPromote == null)
                 {
-                    throw new CommandException("Could not find the latest release for project " + project.Name);
+                    throw new CouldNotFindException("the latest release for project", project.Name);
                 }
             }
             else

--- a/source/OctopusTools/Commands/PromoteReleaseCommand.cs
+++ b/source/OctopusTools/Commands/PromoteReleaseCommand.cs
@@ -34,12 +34,12 @@ namespace OctopusTools.Commands
             Log.Debug("Finding project: " + ProjectName);
             var project = Repository.Projects.FindByName(ProjectName);
             if (project == null)
-                throw new CommandException("Could not find a project named: " + ProjectName);
+                throw new CouldNotFindException("a project named", ProjectName);
 
             Log.Debug("Finding environment: " + FromEnvironmentName);
             var environment = Repository.Environments.FindByName(FromEnvironmentName);
             if (environment == null)
-                throw new CommandException("Could not find an evironment named: " + FromEnvironmentName);
+                throw new CouldNotFindException("an environment named", FromEnvironmentName);
 
             var dashboard = Repository.Dashboards.GetDynamicDashboard(new[] {project.Id}, new[] {environment.Id});
             var dashboardItem = dashboard.Items.Where(e => e.EnvironmentId == environment.Id && e.ProjectId == project.Id)
@@ -48,7 +48,7 @@ namespace OctopusTools.Commands
 
             if (dashboardItem == null)
             {
-                throw new CommandException("Could not find the latest deployment of the project for this environment. Please check that a deployment for this project/environment exists on the dashboard.");
+                throw new CouldNotFindException("latest deployment of the project for this environment. Please check that a deployment for this project/environment exists on the dashboard.");
             }
 
             Log.Debug("Finding release details for release " + dashboardItem.ReleaseVersion);

--- a/source/OctopusTools/Exporters/ProjectExporter.cs
+++ b/source/OctopusTools/Exporters/ProjectExporter.cs
@@ -25,28 +25,31 @@ namespace OctopusTools.Exporters
 
         protected override void Export(Dictionary<string, string> parameters)
         {
-            if (string.IsNullOrWhiteSpace(parameters["Name"])) throw new CommandException("Please specify the name of the project to export using the paramater: --name=XYZ");
+            if (string.IsNullOrWhiteSpace(parameters["Name"]))
+            {
+                throw new CommandException("Please specify the name of the project to export using the paramater: --name=XYZ");
+            }
             var projectName = parameters["Name"];
 
             Log.Debug("Finding project: " + projectName);
             var project = Repository.Projects.FindByName(projectName);
             if (project == null)
-                throw new CommandException("Could not find project named: " + projectName);
+                throw new CouldNotFindException("a project named", projectName);
 
             Log.Debug("Finding project group for project");
             var projectGroup = Repository.ProjectGroups.Get(project.ProjectGroupId);
             if (projectGroup == null)
-                throw new CommandException("Could not find project group for project " + project.Name);
+                throw new CouldNotFindException("project group for project", project.Name);
 
             Log.Debug("Finding variable set for project");
             var variables = Repository.VariableSets.Get(project.VariableSetId);
             if (variables == null)
-                throw new CommandException("Could not find variable set for project " + project.Name);
+                throw new CouldNotFindException("variable set for project", project.Name);
 
             Log.Debug("Finding deployment process for project");
             var deploymentProcess = Repository.DeploymentProcesses.Get(project.DeploymentProcessId);
             if (deploymentProcess == null)
-                throw new CommandException("Could not find deployment process for project " + project.Name);
+                throw new CouldNotFindException("deployment process for project",project.Name);
 
             Log.Debug("Finding NuGet feed for deployment process...");
 
@@ -61,7 +64,7 @@ namespace OctopusTools.Exporters
                         Log.Debug("Finding NuGet feed for step " + step.Name);
                         var feed = Repository.Feeds.Get(nugetFeedId);
                         if (feed == null)
-                            throw new CommandException("Could not find NuGet feed for step " + step.Name);
+                            throw new CouldNotFindException("NuGet feed for step", step.Name);
                         if (nugetFeeds.All(f => f.Id != nugetFeedId))
                         {
                             nugetFeeds.Add(new ReferenceDataItem(feed.Id, feed.Name));
@@ -82,7 +85,7 @@ namespace OctopusTools.Exporters
                         Log.Debug("Finding action template for step " + step.Name);
                         var template = actionTemplateRepository.Get(templateId);
                         if (template == null)
-                            throw new CommandException("Could not find action template for step " + step.Name);
+                            throw new CouldNotFindException("action template for step", step.Name);
                         if (actionTemplates.All(t => t.Id != templateId))
                         {
                             actionTemplates.Add(new ReferenceDataItem(template.Id, template.Name));
@@ -97,7 +100,7 @@ namespace OctopusTools.Exporters
                 var libraryVariableSet = Repository.LibraryVariableSets.Get(libraryVariableSetId);
                 if (libraryVariableSet == null)
                 {
-                    throw new CommandException("Could not find Library Variable Set with Library Variable Set Id " + libraryVariableSetId);
+                    throw new CouldNotFindException("library variable set with Id", libraryVariableSetId);
                 }
 
                 libraryVariableSets.Add(new ReferenceDataItem(libraryVariableSet.Id, libraryVariableSet.Name));
@@ -109,7 +112,7 @@ namespace OctopusTools.Exporters
                 lifecycle = Repository.Lifecycles.Get(project.LifecycleId);
                 if (lifecycle == null)
                 {
-                    throw new CommandException("Could not find lifecycle with Id " + project.LifecycleId + " for project " + project.Name);
+                    throw new CouldNotFindException("lifecycle with Id " + project.LifecycleId + " for project ", project.Name);
                 }
             }
             

--- a/source/OctopusTools/Exporters/ReleaseExporter.cs
+++ b/source/OctopusTools/Exporters/ReleaseExporter.cs
@@ -29,7 +29,7 @@ namespace OctopusTools.Exporters
             Log.Debug("Finding project: " + projectName);
             var project = Repository.Projects.FindByName(projectName);
             if (project == null)
-                throw new CommandException("Could not find a project named: " + projectName);
+                throw new CouldNotFindException("a project named", projectName);
 
             Log.Debug("Finding releases for project...");
             var releases = Repository.Projects.GetReleases(project);

--- a/source/OctopusTools/Infrastructure/CouldNotFindException.cs
+++ b/source/OctopusTools/Infrastructure/CouldNotFindException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace OctopusTools.Infrastructure
+{
+    public class CouldNotFindException : CommandException
+    {
+        public CouldNotFindException(string what)
+            : base("Could not find " + what  + "; either it does not exist or you lack permissions to view it.")
+        {
+        }
+
+        public CouldNotFindException(string what, string quotedName)
+            : this(what + " '" + quotedName + "'")
+        {
+        }
+
+    }
+}

--- a/source/OctopusTools/OctopusTools.csproj
+++ b/source/OctopusTools/OctopusTools.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Commands\OptionGroup.cs" />
     <Compile Include="Importers\BaseValidatedImportSettings.cs" />
     <Compile Include="Importers\CheckedReferences.cs" />
+    <Compile Include="Infrastructure\CouldNotFindException.cs" />
     <Compile Include="Repositories\ActionTemplateRepository.cs" />
     <Compile Include="Repositories\IActionTemplateRepository.cs" />
     <Compile Include="Util\LineSplitter.cs" />


### PR DESCRIPTION
Fixed OctopusDeploy/Issues#1506

Sometimes users use the wrong API key with Octo.exe, and can't find projects or environments because the user they are running as doesn't have permission to see them.

After connecting, print the username we connected as
When we can't find a project/environment/etc., in the error message, suggest it might possibly be a permissions issue

Release note: Octo.exe reports authenticated user and has more helpful error messages