### PR TITLE
Add flag to enable cancellation of the deployment when timeout is reached

### DIFF
--- a/source/OctopusTools.Tests/Commands/DeployReleaseCommandTestFixture.cs
+++ b/source/OctopusTools.Tests/Commands/DeployReleaseCommandTestFixture.cs
@@ -1,0 +1,78 @@
+﻿using NUnit.Framework;
+using Octopus.Client.Model;
+using OctopusTools.Commands;
+using System;
+using System.Collections.Generic;
+using NSubstitute;
+using OctopusTools.Infrastructure;
+
+namespace OctopusTools.Tests.Commands
+{
+    [TestFixture]
+    public class DeployReleaseCommandTestFixture: ApiCommandFixtureBase
+    {
+        DeployReleaseCommand deployReleaseCommand;
+        const string ProjectName = "TestProject";
+        TaskResource taskResource;
+
+        [SetUp]
+        public void SetUp()
+        {
+            deployReleaseCommand = new DeployReleaseCommand(RepositoryFactory, Log);
+
+            var project = new ProjectResource();
+            var release = new ReleaseResource { Version = "1.0.0" };
+            var releases = new ResourceCollection<ReleaseResource>(new[] { release }, new LinkCollection());
+            var deploymentPromotionTarget = new DeploymentPromotionTarget { Name = "TestEnvironment" };
+            var promotionTargets = new List<DeploymentPromotionTarget> { deploymentPromotionTarget };
+            var deploymentTemplate = new DeploymentTemplateResource { PromoteTo = promotionTargets };
+            var deploymentPreviewResource = new DeploymentPreviewResource { StepsToExecute = new List<DeploymentTemplateStep>() };
+            var deployment = new DeploymentResource { TaskId = "1" };
+            taskResource = new TaskResource();
+
+            Repository.Projects.FindByName(ProjectName).Returns(project);
+            Repository.Projects.GetReleases(project).Returns(releases);
+            Repository.Releases.GetPreview(deploymentPromotionTarget).Returns(deploymentPreviewResource);
+            Repository.Releases.GetTemplate(release).Returns(deploymentTemplate);
+            Repository.Deployments.Create(Arg.Any<DeploymentResource>()).Returns(deployment);
+            Repository.Tasks.Get(deployment.TaskId).Returns(taskResource);
+        }
+
+        [Test]
+        public void ShouldCancelDeploymentOnTimeoutIfRequested()
+        {
+            Repository.Tasks
+                .When(x => x.WaitForCompletion(Arg.Any<TaskResource[]>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<Action<TaskResource[]>>()))
+                .Do(x => { throw new TimeoutException(); });
+
+            CommandLineArgs.Add("--project=" + ProjectName);
+            CommandLineArgs.Add("--deploymenttimeout=00:00:01");
+            CommandLineArgs.Add("--deployto=TestEnvironment");
+            CommandLineArgs.Add("--version=latest");
+            CommandLineArgs.Add("--progress");
+            CommandLineArgs.Add("--cancelontimeout");
+
+            Assert.Throws<CommandException>(() => deployReleaseCommand.Execute(CommandLineArgs.ToArray()));
+
+            Repository.Tasks.Received().Cancel(taskResource);
+        }
+
+        [Test]
+        public void ShouldNotCancelDeploymentOnTimeoutIfNotRequested()
+        {
+            Repository.Tasks
+                .When(x => x.WaitForCompletion(Arg.Any<TaskResource[]>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<Action<TaskResource[]>>()))
+                .Do(x => { throw new TimeoutException(); });
+
+            CommandLineArgs.Add("--project=" + ProjectName);
+            CommandLineArgs.Add("--deploymenttimeout=00:00:01");
+            CommandLineArgs.Add("--deployto=TestEnvironment");
+            CommandLineArgs.Add("--version=latest");
+            CommandLineArgs.Add("--progress");
+
+            Assert.Throws<CommandException>(() => deployReleaseCommand.Execute(CommandLineArgs.ToArray()));
+
+            Repository.Tasks.DidNotReceive().Cancel(Arg.Any<TaskResource>());
+        }
+    }
+}

--- a/source/OctopusTools.Tests/OctopusTools.Tests.csproj
+++ b/source/OctopusTools.Tests/OctopusTools.Tests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Client\OctopusSessionFactoryFixture.cs" />
     <Compile Include="Commands\ApiCommandFixture.cs" />
     <Compile Include="Commands\ApiCommandFixtureBase.cs" />
+    <Compile Include="Commands\DeployReleaseCommandTestFixture.cs" />
     <Compile Include="Commands\DummyApiCommand.cs" />
     <Compile Include="Commands\ListEnvironmentsCommandFixture.cs" />
     <Compile Include="Commands\ListProjectsCommandFixture.cs" />

--- a/source/OctopusTools/Commands/DeploymentCommandBase.cs
+++ b/source/OctopusTools/Commands/DeploymentCommandBase.cs
@@ -26,6 +26,7 @@ namespace OctopusTools.Commands
             options.Add("forcepackagedownload", "[Optional] Whether to force downloading of already installed packages (flag, default false).", v => ForcePackageDownload = true);
             options.Add("waitfordeployment", "[Optional] Whether to wait synchronously for deployment to finish.", v => WaitForDeployment = true);
             options.Add("deploymenttimeout=", "[Optional] Specifies maximum time (timespan format) that the console session will wait for the deployment to finish(default 00:10:00). This will not stop the deployment.", v => DeploymentTimeout = TimeSpan.Parse(v));
+            options.Add("cancelontimeout", "[Optional] Whether to cancel the deployment if the deployment timeout is reached (flag, default false).", v => CancelOnTimeout = true);
             options.Add("deploymentchecksleepcycle=", "[Optional] Specifies how much time (timespan format) should elapse between deployment status checks (default 00:00:10)", v => DeploymentStatusCheckSleepCycle = TimeSpan.Parse(v));
             options.Add("guidedfailure=", "[Optional] Whether to use Guided Failure mode. (True or False. If not specified, will use default setting from environment)", v => UseGuidedFailure = bool.Parse(v));
             options.Add("specificmachines=", "[Optional] A comma-separated list of machines names to target in the deployed environment. If not specified all machines in the environment will be considered.", v => SpecificMachineNames.AddRange(v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(m => m.Trim())));
@@ -42,6 +43,7 @@ namespace OctopusTools.Commands
         protected bool? UseGuidedFailure { get; set; }
         protected bool WaitForDeployment { get; set; }
         protected TimeSpan DeploymentTimeout { get; set; }
+        protected bool CancelOnTimeout { get; set; }
         protected TimeSpan DeploymentStatusCheckSleepCycle { get; set; }
         protected List<string> SpecificMachineNames { get; set; }
         protected List<string> SkipStepNames { get; set; }
@@ -239,6 +241,9 @@ namespace OctopusTools.Commands
             catch (TimeoutException e)
             {
                 Log.Error(e.Message);
+
+                CancelDeploymentOnTimeoutIfRequested(deploymentTasks);
+
                 var guidedFailureDeployments =
                     from d in deployments
                     where d.UseGuidedFailure
@@ -254,6 +259,24 @@ namespace OctopusTools.Commands
                 }
                 throw new CommandException(e.Message);
             }
+        }
+
+        private void CancelDeploymentOnTimeoutIfRequested(List<TaskResource> deploymentTasks)
+        {
+            if (!CancelOnTimeout)
+                return;
+
+            deploymentTasks.ForEach(task => {
+                Log.WarnFormat("Cancelling deployment task '{0}'", task.Description);
+                try
+                {
+                    Repository.Tasks.Cancel(task);
+                }
+                catch(Exception ex)
+                {
+                    Log.ErrorFormat("Failed to cancel deployment task '{0}': {1}", task.Description, ex.Message);
+                }
+            });
         }
 
         void PrintTaskOutput(TaskResource[] taskResources)


### PR DESCRIPTION
We found that the --deploymenttimeout parameter had a bit of a misleading help text, which @Dalmirog updated in #62, based on the [conversation](http://help.octopusdeploy.com/discussions/questions/6140-deploymenttimeout-failing-teamcity-build-but-not-cancelling-octopus-deployment) we had on help.octopusdeploy.com.

We expected that the deployment timeout should cancel the build in octopus, which it did not. This pull request adds a new flag to octo.exe that cancels the deployment(s) if the timeout is reached. 