### PR TITLE
Move octo.exe into Tools Folder

### DIFF
--- a/source/OctopusTools/DUMMY.txt
+++ b/source/OctopusTools/DUMMY.txt
@@ -1,2 +1,0 @@
-This file is included as a fix to make this work with NuGet 3
-https://github.com/OctopusDeploy/Issues/issues/2100

--- a/source/OctopusTools/OctopusTools.csproj
+++ b/source/OctopusTools/OctopusTools.csproj
@@ -190,7 +190,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="DUMMY.txt" />
     <Content Include="Properties\Icon.ico" />
   </ItemGroup>
   <ItemGroup>

--- a/source/OctopusTools/OctopusTools.csproj
+++ b/source/OctopusTools/OctopusTools.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Util\UriExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="init.ps1" />
     <None Include="app.config" />
     <None Include="OctopusTools.nuspec">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/source/OctopusTools/OctopusTools.nuspec
+++ b/source/OctopusTools/OctopusTools.nuspec
@@ -20,6 +20,7 @@
     <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
+    <file src="init.ps1" target="tools" />
     <file src="Octo.exe" target="tools" />
     <file src="Octo.exe.config" target="tools" />
   </files>

--- a/source/OctopusTools/OctopusTools.nuspec
+++ b/source/OctopusTools/OctopusTools.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>OctopusTools</id>
     <title>OctopusTools</title>
-    <version>1.0.0.0</version>
+    <version>$version$</version>
     <authors>Octopus Deploy</authors>
     <owners>Octopus Deploy</owners>
     <summary>Create, deploy and promote releases using Octopus Deploy.</summary>
@@ -20,8 +20,7 @@
     <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
-    <file src="DUMMY.txt" target="lib" />
-    <file src="Octo.exe" />
-    <file src="Octo.exe.config" />
+    <file src="Octo.exe" target="tools" />
+    <file src="Octo.exe.config" target="tools" />
   </files>
 </package>

--- a/source/OctopusTools/init.ps1
+++ b/source/OctopusTools/init.ps1
@@ -1,0 +1,6 @@
+﻿param($installPath, $toolsPath, $package, $project)
+
+$path = $env:PATH
+if (!$path.Contains($toolsPath)) {
+    $env:PATH += ";$toolsPath"
+}

--- a/tools/Build.proj
+++ b/tools/Build.proj
@@ -73,6 +73,7 @@
       <!-- Octo.exe is copied via output of ILMerge above -->
       <PackagedFiles Include="$(Root)\source\OctopusTools\bin\Octo.exe.config" />
       <PackagedFiles Include="$(Root)\source\OctopusTools\bin\OctopusTools.nuspec" />
+      <PackagedFiles Include="$(Root)\source\OctopusTools\init.ps1" />
     </ItemGroup>
     <Copy SourceFiles="@(PackagedFiles)" DestinationFolder="$(Root)\build\Temp" />
     

--- a/tools/Build.proj
+++ b/tools/Build.proj
@@ -73,7 +73,6 @@
       <!-- Octo.exe is copied via output of ILMerge above -->
       <PackagedFiles Include="$(Root)\source\OctopusTools\bin\Octo.exe.config" />
       <PackagedFiles Include="$(Root)\source\OctopusTools\bin\OctopusTools.nuspec" />
-      <PackagedFiles Include="$(Root)\source\OctopusTools\DUMMY.txt" />
     </ItemGroup>
     <Copy SourceFiles="@(PackagedFiles)" DestinationFolder="$(Root)\build\Temp" />
     


### PR DESCRIPTION
This is a potential ​*breaking change*​ with the NuGet package we publish to NuGet.org which is to move `octo.exe` into the `tools` folder. This means we don’t need to `DUMMY.txt` hack to make it install (current process), and `octo.exe` will be added to the `$env:PATH` so you can run `octo.exe` commands directly from the ​*PowerShell Manager Console*​.