### PR TITLE
Load additional parameters from a file when --configfile is passed

### DIFF
--- a/source/OctopusTools.Tests/Commands/ApiCommandFixture.cs
+++ b/source/OctopusTools.Tests/Commands/ApiCommandFixture.cs
@@ -15,7 +15,7 @@ namespace OctopusTools.Tests.Commands
         [SetUp]
         public void SetUp()
         {
-            apiCommand = new DummyApiCommand(RepositoryFactory, Log);
+            apiCommand = new DummyApiCommand(RepositoryFactory, Log, FileSystem);
         }
 
         [Test]

--- a/source/OctopusTools.Tests/Commands/ApiCommandFixtureBase.cs
+++ b/source/OctopusTools.Tests/Commands/ApiCommandFixtureBase.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using Octopus.Client;
 using Octopus.Client.Model;
 using OctopusTools.Commands;
+using OctopusTools.Util;
 
 namespace OctopusTools.Tests.Commands
 {
@@ -26,6 +27,8 @@ namespace OctopusTools.Tests.Commands
             RepositoryFactory = Substitute.For<IOctopusRepositoryFactory>();
             RepositoryFactory.CreateRepository(null).ReturnsForAnyArgs(Repository);
 
+            FileSystem = Substitute.For<IOctopusFileSystem>();
+
             CommandLineArgs = new List<string>
             {
                 "--server=http://the-server",
@@ -38,6 +41,8 @@ namespace OctopusTools.Tests.Commands
         public IOctopusRepositoryFactory RepositoryFactory { get; set; }
 
         public IOctopusRepository Repository { get; set; }
+
+        public IOctopusFileSystem FileSystem { get; set; }
 
         public List<string> CommandLineArgs { get; set; }
 

--- a/source/OctopusTools.Tests/Commands/CreateReleaseCommandFixture.cs
+++ b/source/OctopusTools.Tests/Commands/CreateReleaseCommandFixture.cs
@@ -1,0 +1,35 @@
+﻿using NSubstitute;
+using NUnit.Framework;
+using OctopusTools.Commands;
+using OctopusTools.Infrastructure;
+using OctopusTools.Util;
+
+namespace OctopusTools.Tests.Commands
+{
+    public class CreateReleaseCommandFixture : ApiCommandFixture
+    {
+        CreateReleaseCommand createReleaseCommand;
+        IPackageVersionResolver versionResolver;
+
+        [SetUp]
+        public void SetUp()
+        {
+            base.SetUp();
+            versionResolver = Substitute.For<IPackageVersionResolver>();
+        }
+
+        [Test]
+        public void ShouldLoadOptionsFromFile()
+        {
+            createReleaseCommand = new CreateReleaseCommand(RepositoryFactory, Log, new OctopusPhysicalFileSystem(Log), versionResolver);
+
+            Assert.Throws<CouldNotFindException>(delegate {
+                createReleaseCommand.Execute("--configfile=Commands/Resources/CreateRelease.config.txt");
+            });
+            
+            Assert.AreEqual("Test Project", createReleaseCommand.ProjectName);
+            Assert.AreEqual("1.0.0", createReleaseCommand.VersionNumber);
+            Assert.AreEqual("Test config file.", createReleaseCommand.ReleaseNotes);
+        }
+    }
+}

--- a/source/OctopusTools.Tests/Commands/CreateReleaseCommandFixture.cs
+++ b/source/OctopusTools.Tests/Commands/CreateReleaseCommandFixture.cs
@@ -6,15 +6,14 @@ using OctopusTools.Util;
 
 namespace OctopusTools.Tests.Commands
 {
-    public class CreateReleaseCommandFixture : ApiCommandFixture
+    public class CreateReleaseCommandFixture : ApiCommandFixtureBase
     {
         CreateReleaseCommand createReleaseCommand;
         IPackageVersionResolver versionResolver;
 
         [SetUp]
         public void SetUp()
-        {
-            base.SetUp();
+        {            
             versionResolver = Substitute.For<IPackageVersionResolver>();
         }
 

--- a/source/OctopusTools.Tests/Commands/DeployReleaseCommandTestFixture.cs
+++ b/source/OctopusTools.Tests/Commands/DeployReleaseCommandTestFixture.cs
@@ -18,7 +18,7 @@ namespace OctopusTools.Tests.Commands
         [SetUp]
         public void SetUp()
         {
-            deployReleaseCommand = new DeployReleaseCommand(RepositoryFactory, Log);
+            deployReleaseCommand = new DeployReleaseCommand(RepositoryFactory, Log, FileSystem);
 
             var project = new ProjectResource();
             var release = new ReleaseResource { Version = "1.0.0" };

--- a/source/OctopusTools.Tests/Commands/DummyApiCommand.cs
+++ b/source/OctopusTools.Tests/Commands/DummyApiCommand.cs
@@ -5,13 +5,15 @@ using System.Text;
 using log4net;
 using NUnit.Framework;
 using OctopusTools.Commands;
+using OctopusTools.Util;
 
 namespace OctopusTools.Tests.Commands
 {
     public class DummyApiCommand : ApiCommand
     {
         string pill;
-        public DummyApiCommand(IOctopusRepositoryFactory repositoryFactory, ILog log) : base(repositoryFactory, log)
+        public DummyApiCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem)
+            : base(repositoryFactory, log, fileSystem)
         {
             var options = Options.For("Dummy");
             options.Add("pill=", "Red or Blue. Blue, the story ends. Red, stay in Wonderland and see how deep the rabbit hole goes.", v => pill = v);

--- a/source/OctopusTools.Tests/Commands/ListEnvironmentsCommandFixture.cs
+++ b/source/OctopusTools.Tests/Commands/ListEnvironmentsCommandFixture.cs
@@ -15,7 +15,7 @@ namespace OctopusTools.Tests.Commands
         [SetUp]
         public void SetUp()
         {
-            listEnvironmentsCommand = new ListEnvironmentsCommand(RepositoryFactory, Log);
+            listEnvironmentsCommand = new ListEnvironmentsCommand(RepositoryFactory, Log, FileSystem);
         }
 
         [Test]

--- a/source/OctopusTools.Tests/Commands/ListProjectsCommandFixture.cs
+++ b/source/OctopusTools.Tests/Commands/ListProjectsCommandFixture.cs
@@ -15,7 +15,7 @@ namespace OctopusTools.Tests.Commands
         [SetUp]
         public void SetUp()
         {
-            listProjectsCommand = new ListProjectsCommand(RepositoryFactory, Log);
+            listProjectsCommand = new ListProjectsCommand(RepositoryFactory, Log, FileSystem);
         }
 
         [Test]

--- a/source/OctopusTools.Tests/Commands/ListReleasesCommandFixture.cs
+++ b/source/OctopusTools.Tests/Commands/ListReleasesCommandFixture.cs
@@ -17,7 +17,7 @@ namespace OctopusTools.Tests.Commands
         [SetUp]
         public void SetUp()
         {
-            listReleasesCommand = new ListReleasesCommand(RepositoryFactory, Log);
+            listReleasesCommand = new ListReleasesCommand(RepositoryFactory, Log, FileSystem);
         }
 
         [Test]

--- a/source/OctopusTools.Tests/Commands/Resources/CreateRelease.config.txt
+++ b/source/OctopusTools.Tests/Commands/Resources/CreateRelease.config.txt
@@ -1,0 +1,5 @@
+﻿server=https://test-server-url/api/
+apikey=API-test
+project=Test Project
+releaseNumber=1.0.0
+releasenotes=Test config file.

--- a/source/OctopusTools.Tests/OctopusTools.Tests.csproj
+++ b/source/OctopusTools.Tests/OctopusTools.Tests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Commands\PackageVersionResolverFixture.cs" />
     <Compile Include="Commands\HelpCommandFixture.cs" />
     <Compile Include="Commands\OptionsFixture.cs" />
+    <Compile Include="Commands\CreateReleaseCommandFixture.cs" />
     <Compile Include="Commands\SpeakCommand.cs" />
     <Compile Include="Extensions\TimeSpanExtensionsFixture.cs" />
     <Compile Include="Helpers\TestCommandExtensions.cs" />
@@ -96,6 +97,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <Content Include="Commands\Resources\CreateRelease.config.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/source/OctopusTools/Commands/ApiCommand.cs
+++ b/source/OctopusTools/Commands/ApiCommand.cs
@@ -39,7 +39,7 @@ namespace OctopusTools.Commands
             options.Add("apiKey=", "Your API key. Get this from the user profile page.", v => apiKey = v);
             options.Add("user=", "[Optional] Username to use when authenticating with the server.", v => username = v);
             options.Add("pass=", "[Optional] Password to use when authenticating with the server.", v => password = v);
-            options.Add("configFile=", "[Optional] Text file of default values, with one 'key = value' per line.", v => ReadAdditionalInputsFromConfigurationFile(options, v));
+            options.Add("configFile=", "[Optional] Text file of default values, with one 'key = value' per line.", v => ReadAdditionalInputsFromConfigurationFile(v));
             options.Add("debug", "[Optional] Enable debug logging", v => enableDebugging = true);
             options.Add("ignoreSslErrors", "[Optional] Set this flag if your Octopus server uses HTTPS but the certificate is not trusted on this machine. Any certificate errors will be ignored. WARNING: this option may create a security vulnerability.", v => ignoreSslErrors = true);
             options.Add("enableServiceMessages", "[Optional] Enable TeamCity service messages when logging.", v => log.EnableServiceMessages());
@@ -145,7 +145,7 @@ namespace OctopusTools.Commands
             return new NetworkCredential(username, password);
         }
 
-        protected List<string> ReadAdditionalInputsFromConfigurationFile(OptionSet options, string configFile)
+        protected List<string> ReadAdditionalInputsFromConfigurationFile(string configFile)
         {
             configFile = fileSystem.GetFullPath(configFile);
 
@@ -170,7 +170,7 @@ namespace OctopusTools.Commands
                 }
             }
 
-            var remainingArguments = options.Parse(results);
+            var remainingArguments = optionGroups.Parse(results);
             if (remainingArguments.Count > 0)
                 throw new CommandException("Unrecognized arguments in configuration file: " + string.Join(", ", remainingArguments));
 

--- a/source/OctopusTools/Commands/ApiCommand.cs
+++ b/source/OctopusTools/Commands/ApiCommand.cs
@@ -10,6 +10,7 @@ using Octopus.Client;
 using Octopus.Client.Model;
 using OctopusTools.Diagnostics;
 using OctopusTools.Infrastructure;
+using OctopusTools.Util;
 
 namespace OctopusTools.Commands
 {
@@ -17,6 +18,7 @@ namespace OctopusTools.Commands
     {
         readonly ILog log;
         readonly IOctopusRepositoryFactory repositoryFactory;
+        readonly IOctopusFileSystem fileSystem;
         string apiKey;
         bool enableDebugging;
         bool ignoreSslErrors;
@@ -26,10 +28,11 @@ namespace OctopusTools.Commands
         string username;
         readonly Options optionGroups = new Options();
 
-        protected ApiCommand(IOctopusRepositoryFactory repositoryFactory, ILog log)
+        protected ApiCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem)
         {
             this.repositoryFactory = repositoryFactory;
             this.log = log;
+            this.fileSystem = fileSystem;
 
             var options = optionGroups.For("Common options");
             options.Add("server=", "The base URL for your Octopus server - e.g., http://your-octopus/", v => serverBaseUrl = v);
@@ -52,6 +55,11 @@ namespace OctopusTools.Commands
         protected IOctopusRepository Repository
         {
             get { return repository; }
+        }
+
+        protected IOctopusFileSystem FileSystem
+        {
+            get {  return fileSystem; }
         }
 
         public void GetHelp(TextWriter writer)
@@ -139,17 +147,18 @@ namespace OctopusTools.Commands
 
         protected List<string> ReadAdditionalInputsFromConfigurationFile(OptionSet options, string configFile)
         {
-            configFile = Path.GetFullPath(configFile);
+            configFile = fileSystem.GetFullPath(configFile);
 
             log.Debug("Loading additional arguments from config file: " + configFile);
 
-            if (!File.Exists(configFile))
+            if (!fileSystem.FileExists(configFile))
             {
                 throw new CommandException("Unable to find config file " + configFile);
             }
 
             var results = new List<string>();
-            using (var file = new StreamReader(configFile))
+            using (var fileStream = fileSystem.OpenFile(configFile, FileAccess.Read))
+            using (var file = new StreamReader(fileStream))
             {
                 string line;
                 while ((line = file.ReadLine()) != null)

--- a/source/OctopusTools/Commands/CreateEnvironmentCommand.cs
+++ b/source/OctopusTools/Commands/CreateEnvironmentCommand.cs
@@ -2,14 +2,15 @@
 using log4net;
 using Octopus.Client.Model;
 using OctopusTools.Infrastructure;
+using OctopusTools.Util;
 
 namespace OctopusTools.Commands
 {
     [Command("create-environment", Description = "Creates a deployment environment")]
     public class CreateEnvironmentCommand : ApiCommand
     {
-        public CreateEnvironmentCommand(IOctopusRepositoryFactory repositoryFactory, ILog log)
-            : base(repositoryFactory, log)
+        public CreateEnvironmentCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem)
+            : base(repositoryFactory, log, fileSystem)
         {
             var options = Options.For("Environment creation");
             options.Add("name=", "The name of the environment", v => EnvironmentName = v);

--- a/source/OctopusTools/Commands/CreateProjectCommand.cs
+++ b/source/OctopusTools/Commands/CreateProjectCommand.cs
@@ -2,14 +2,15 @@
 using log4net;
 using Octopus.Client.Model;
 using OctopusTools.Infrastructure;
+using OctopusTools.Util;
 
 namespace OctopusTools.Commands
 {
     [Command("create-project", Description = "Creates a project")]
     public class CreateProjectCommand : ApiCommand
     {
-        public CreateProjectCommand(IOctopusRepositoryFactory repositoryFactory, ILog log)
-            : base(repositoryFactory, log)
+        public CreateProjectCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem)
+            : base(repositoryFactory, log, fileSystem)
         {
             var options = Options.For("Project creation");
             options.Add("name=", "The name of the project", v => ProjectName = v);

--- a/source/OctopusTools/Commands/CreateReleaseCommand.cs
+++ b/source/OctopusTools/Commands/CreateReleaseCommand.cs
@@ -9,6 +9,7 @@ using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
 using OctopusTools.Diagnostics;
 using OctopusTools.Infrastructure;
+using OctopusTools.Util;
 
 namespace OctopusTools.Commands
 {
@@ -17,8 +18,8 @@ namespace OctopusTools.Commands
     {
         readonly IPackageVersionResolver versionResolver;
 
-        public CreateReleaseCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IPackageVersionResolver versionResolver)
-            : base(repositoryFactory, log)
+        public CreateReleaseCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem, IPackageVersionResolver versionResolver)
+            : base(repositoryFactory, log, fileSystem)
         {
             this.versionResolver = versionResolver;
 

--- a/source/OctopusTools/Commands/DeleteReleasesCommand.cs
+++ b/source/OctopusTools/Commands/DeleteReleasesCommand.cs
@@ -3,13 +3,15 @@ using System.Collections.Generic;
 using log4net;
 using Octopus.Client.Model;
 using OctopusTools.Infrastructure;
+using OctopusTools.Util;
 
 namespace OctopusTools.Commands
 {
     [Command("delete-releases", Description = "Deletes a range of releases")]
     public class DeleteReleasesCommand : ApiCommand
     {
-        public DeleteReleasesCommand(IOctopusRepositoryFactory repositoryFactory, ILog log) : base(repositoryFactory, log)
+        public DeleteReleasesCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem)
+            : base(repositoryFactory, log, fileSystem)
         {
             var options = Options.For("Deletion");
             options.Add("project=", "Name of the project", v => ProjectName = v);

--- a/source/OctopusTools/Commands/DeployReleaseCommand.cs
+++ b/source/OctopusTools/Commands/DeployReleaseCommand.cs
@@ -4,14 +4,15 @@ using System.Linq;
 using log4net;
 using Octopus.Client.Model;
 using OctopusTools.Infrastructure;
+using OctopusTools.Util;
 
 namespace OctopusTools.Commands
 {
     [Command("deploy-release", Description = "Deploys a release.")]
     public class DeployReleaseCommand : DeploymentCommandBase
     {
-        public DeployReleaseCommand(IOctopusRepositoryFactory repositoryFactory, ILog log)
-            : base(repositoryFactory, log)
+        public DeployReleaseCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem)
+            : base(repositoryFactory, log, fileSystem)
         {
             DeployToEnvironmentNames = new List<string>();
             DeploymentStatusCheckSleepCycle = TimeSpan.FromSeconds(10);

--- a/source/OctopusTools/Commands/DeploymentCommandBase.cs
+++ b/source/OctopusTools/Commands/DeploymentCommandBase.cs
@@ -16,7 +16,8 @@ namespace OctopusTools.Commands
     {
         readonly VariableDictionary variables = new VariableDictionary();
 
-        protected DeploymentCommandBase(IOctopusRepositoryFactory repositoryFactory, ILog log) : base(repositoryFactory, log)
+        protected DeploymentCommandBase(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem)
+            : base(repositoryFactory, log, fileSystem)
         {
             SpecificMachineNames = new List<string>();
             SkipStepNames = new List<string>();

--- a/source/OctopusTools/Commands/DumpDeploymentsCommand.cs
+++ b/source/OctopusTools/Commands/DumpDeploymentsCommand.cs
@@ -6,6 +6,7 @@ using System.Xml;
 using log4net;
 using Octopus.Client.Model;
 using OctopusTools.Infrastructure;
+using OctopusTools.Util;
 
 namespace OctopusTools.Commands
 {
@@ -14,8 +15,8 @@ namespace OctopusTools.Commands
     {
         string filePath;
 
-        public DumpDeploymentsCommand(IOctopusRepositoryFactory repositoryFactory, ILog log)
-            : base(repositoryFactory, log)
+        public DumpDeploymentsCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem)
+            : base(repositoryFactory, log, fileSystem)
         {
             var options = Options.For("Dumper");
             options.Add("filePath=", "The full path and name of the export file", delegate(string v) { filePath = v; });

--- a/source/OctopusTools/Commands/ExportCommand.cs
+++ b/source/OctopusTools/Commands/ExportCommand.cs
@@ -9,13 +9,11 @@ namespace OctopusTools.Commands
     public class ExportCommand : ApiCommand
     {
         readonly IExporterLocator exporterLocator;
-        readonly IOctopusFileSystem fileSystem;
 
         public ExportCommand(IExporterLocator exporterLocator, IOctopusFileSystem fileSystem, IOctopusRepositoryFactory repositoryFactory, ILog log)
-            : base(repositoryFactory, log)
+            : base(repositoryFactory, log, fileSystem)
         {
             this.exporterLocator = exporterLocator;
-            this.fileSystem = fileSystem;
 
             var options = Options.For("Export");
             options.Add("type=", "The type to export", v => Type = v);
@@ -37,7 +35,7 @@ namespace OctopusTools.Commands
             if (string.IsNullOrWhiteSpace(FilePath)) throw new CommandException("Please specify the full path and name of the export file using the parameter: --filePath=XYZ");
 
             Log.Debug("Finding exporter '" + Type + "'");
-            var exporter = exporterLocator.Find(Type, Repository, fileSystem, Log);
+            var exporter = exporterLocator.Find(Type, Repository, FileSystem, Log);
             if (exporter == null)
                 throw new CommandException("Error: Unrecognized exporter '" + Type + "'");
 

--- a/source/OctopusTools/Commands/ImportCommand.cs
+++ b/source/OctopusTools/Commands/ImportCommand.cs
@@ -8,14 +8,12 @@ namespace OctopusTools.Commands
     [Command("import", Description = "Imports an Octopus object from an export file")]
     public class ImportCommand : ApiCommand
     {
-        readonly IOctopusFileSystem fileSystem;
         readonly IImporterLocator importerLocator;
 
         public ImportCommand(IImporterLocator importerLocator, IOctopusFileSystem fileSystem, IOctopusRepositoryFactory repositoryFactory, ILog log)
-            : base(repositoryFactory, log)
+            : base(repositoryFactory, log, fileSystem)
         {
             this.importerLocator = importerLocator;
-            this.fileSystem = fileSystem;
 
             var options = Options.For("Import");
             options.Add("type=", "The Octopus object type to import", v => Type = v);
@@ -35,7 +33,7 @@ namespace OctopusTools.Commands
             if (string.IsNullOrWhiteSpace(FilePath)) throw new CommandException("Please specify the full path and name of the export file to import using the parameter: --filePath=XYZ");
 
             Log.Debug("Finding importer '" + Type + "'");
-            var importer = importerLocator.Find(Type, Repository, fileSystem, Log);
+            var importer = importerLocator.Find(Type, Repository, FileSystem, Log);
             if (importer == null)
                 throw new CommandException("Error: Unrecognized importer '" + Type + "'");
 

--- a/source/OctopusTools/Commands/ListEnvironmentsCommand.cs
+++ b/source/OctopusTools/Commands/ListEnvironmentsCommand.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using log4net;
+using OctopusTools.Util;
 
 namespace OctopusTools.Commands
 {
     public class ListEnvironmentsCommand : ApiCommand
     {
-        public ListEnvironmentsCommand(IOctopusRepositoryFactory repositoryFactory, ILog log) : base(repositoryFactory, log)
+        public ListEnvironmentsCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem)
+            : base(repositoryFactory, log, fileSystem)
         {
         }
 

--- a/source/OctopusTools/Commands/ListLatestDeploymentsCommand.cs
+++ b/source/OctopusTools/Commands/ListLatestDeploymentsCommand.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using log4net;
 using NuGet;
 using Octopus.Client.Model;
+using OctopusTools.Util;
 
 namespace OctopusTools.Commands
 {
@@ -13,8 +14,8 @@ namespace OctopusTools.Commands
         readonly HashSet<string> environments = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         readonly HashSet<string> projects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        public ListLatestDeploymentsCommand(IOctopusRepositoryFactory repositoryFactory, ILog log)
-            : base(repositoryFactory, log)
+        public ListLatestDeploymentsCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem)
+            : base(repositoryFactory, log, fileSystem)
         {
             var options = Options.For("Listing");
             options.Add("project=", "Name of a project to filter by. Can be specified many times.", v => projects.Add(v));
@@ -34,11 +35,11 @@ namespace OctopusTools.Commands
             if (environments.Count > 0)
             {
                 Log.Debug("Loading environments...");
-                environmentsById.AddRange(Repository.Environments.FindByNames(environments.ToArray()).Select(p => new KeyValuePair<string, string>(p.Id, p.Name)));
+                CollectionExtensions.AddRange(environmentsById, Repository.Environments.FindByNames(environments.ToArray()).Select(p => new KeyValuePair<string, string>(p.Id, p.Name)));
             }
             else
             {
-                environmentsById.AddRange(Repository.Environments.FindAll().Select(p => new KeyValuePair<string, string>(p.Id, p.Name)));
+                CollectionExtensions.AddRange(environmentsById, Repository.Environments.FindAll().Select(p => new KeyValuePair<string, string>(p.Id, p.Name)));
             }
 
             var deployments = Repository.Deployments.FindAll(projectsFilter, environments.Count > 0 ? environmentsById.Keys.ToArray() : new string[] {});

--- a/source/OctopusTools/Commands/ListProjectsCommand.cs
+++ b/source/OctopusTools/Commands/ListProjectsCommand.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using log4net;
+using OctopusTools.Util;
 
 namespace OctopusTools.Commands
 {
     [Command("list-projects", Description = "Lists all projects")]
     public class ListProjectsCommand : ApiCommand
     {
-        public ListProjectsCommand(IOctopusRepositoryFactory repositoryFactory, ILog log) : base(repositoryFactory, log)
+        public ListProjectsCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem)
+            : base(repositoryFactory, log, fileSystem)
         {
         }
 

--- a/source/OctopusTools/Commands/ListReleasesCommand.cs
+++ b/source/OctopusTools/Commands/ListReleasesCommand.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using log4net;
 using Octopus.Client.Model;
+using OctopusTools.Util;
 
 namespace OctopusTools.Commands
 {
@@ -11,7 +12,8 @@ namespace OctopusTools.Commands
     {
         readonly HashSet<string> projects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        public ListReleasesCommand(IOctopusRepositoryFactory repositoryFactory, ILog log) : base(repositoryFactory, log)
+        public ListReleasesCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem)
+            : base(repositoryFactory, log, fileSystem)
         {
             var options = Options.For("Listing");
             options.Add("project=", "Name of a project to filter by. Can be specified many times.", v => projects.Add(v));

--- a/source/OctopusTools/Commands/PromoteReleaseCommand.cs
+++ b/source/OctopusTools/Commands/PromoteReleaseCommand.cs
@@ -4,13 +4,15 @@ using System.Linq;
 using log4net;
 using Octopus.Client.Model;
 using OctopusTools.Infrastructure;
+using OctopusTools.Util;
 
 namespace OctopusTools.Commands
 {
     [Command("promote-release", Description = "Promotes a release.")]
     public class PromoteReleaseCommand : DeploymentCommandBase
     {
-        public PromoteReleaseCommand(IOctopusRepositoryFactory repositoryFactory, ILog log) : base(repositoryFactory, log)
+        public PromoteReleaseCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem)
+            : base(repositoryFactory, log, fileSystem)
         {
             DeployToEnvironmentNames = new List<string>();
 


### PR DESCRIPTION
Did a refactor using `IOctopusFileSystem` instead of `File` so it's a noisy PR.

The important parts are `CreateReleaseCommandFixture.cs` and `CreateRelease.config.txt` which test that parameters can be loaded from a file.

The implementation change is `ApiCommand.cs` line 173 that uses `optionsGroup` instead of just `options`.
