### PR TITLE
Add clean-machines Command

### DIFF
--- a/source/OctopusTools.Tests/Commands/Class1.cs
+++ b/source/OctopusTools.Tests/Commands/Class1.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Client.Model;
+using OctopusTools.Commands;
+using OctopusTools.Infrastructure;
+
+namespace OctopusTools.Tests.Commands
+{
+    [TestFixture]
+    public class CleanEnvironmentCommandFixture : ApiCommandFixtureBase
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            listMachinesCommand = new CleanEnvironmentCommand(RepositoryFactory, Log, FileSystem);
+        }
+
+        CleanEnvironmentCommand listMachinesCommand;
+
+        [Test]
+        public void ShouldCleanEnvironmentWithEnvironmentAndStatusArgs()
+        {
+            CommandLineArgs.Add("-environment=Development");
+            CommandLineArgs.Add("-status=Offline");
+
+            Repository.Environments.FindByNames(Arg.Any<string[]>()).Returns(new List<EnvironmentResource>
+            {
+                new EnvironmentResource {Name = "Development", Id = "Environments-001"}
+            });
+
+            Repository.Machines.FindMany(Arg.Any<Func<MachineResource, bool>>()).Returns(new List<MachineResource>
+            {
+                new MachineResource
+                {
+                    Name = "PC01234",
+                    Id = "Machines-001",
+                    Status = MachineModelStatus.Online,
+                    EnvironmentIds = new ReferenceCollection("Environments-001")
+                },
+                new MachineResource
+                {
+                    Name = "PC01466",
+                    Id = "Machines-002",
+                    Status = MachineModelStatus.Offline,
+                    EnvironmentIds = new ReferenceCollection("Environments-001")
+                },
+                new MachineResource
+                {
+                    Name = "PC01996",
+                    Id = "Machines-003",
+                    Status = MachineModelStatus.Offline,
+                    EnvironmentIds = new ReferenceCollection("Environments-001")
+                }
+            });
+
+            listMachinesCommand.Execute(CommandLineArgs.ToArray());
+
+            Log.Received().Info("Machines: 2");
+            Log.Received().InfoFormat(" - {0} {1} (ID: {2})", "PC01466", MachineModelStatus.Offline, "Machines-002");
+            Log.Received().InfoFormat(" - {0} {1} (ID: {2})", "PC01996", MachineModelStatus.Offline, "Machines-003");
+            Log.DidNotReceive().InfoFormat(" - {0} {1} (ID: {2})", "PC01234", MachineModelStatus.Online, "Machines-001");
+        }
+
+        [Test, ExpectedException(typeof(CommandException), ExpectedMessage = "Please specify an environment name using the parameter: --environment=XYZ")]
+        public void ShouldNotCleanEnvironmentWithMissingEnvironmentArgs()
+        {
+            listMachinesCommand.Execute(CommandLineArgs.ToArray());
+        }
+
+        [Test, ExpectedException(typeof(CommandException), ExpectedMessage = "Please specify status using the parameter: --status=Offline")]
+        public void ShouldNotCleanEnvironmentWithMissingStatusArgs()
+        {
+            CommandLineArgs.Add("-environment=Development");
+            listMachinesCommand.Execute(CommandLineArgs.ToArray());
+        }
+    }
+}

--- a/source/OctopusTools.Tests/OctopusTools.Tests.csproj
+++ b/source/OctopusTools.Tests/OctopusTools.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Client\OctopusSessionFactoryFixture.cs" />
     <Compile Include="Commands\ApiCommandFixture.cs" />
     <Compile Include="Commands\ApiCommandFixtureBase.cs" />
+    <Compile Include="Commands\Class1.cs" />
     <Compile Include="Commands\DeployReleaseCommandTestFixture.cs" />
     <Compile Include="Commands\DummyApiCommand.cs" />
     <Compile Include="Commands\ListEnvironmentsCommandFixture.cs" />

--- a/source/OctopusTools.Tests/OctopusTools.Tests.csproj
+++ b/source/OctopusTools.Tests/OctopusTools.Tests.csproj
@@ -74,7 +74,7 @@
     <Compile Include="Client\OctopusSessionFactoryFixture.cs" />
     <Compile Include="Commands\ApiCommandFixture.cs" />
     <Compile Include="Commands\ApiCommandFixtureBase.cs" />
-    <Compile Include="Commands\Class1.cs" />
+    <Compile Include="Commands\CleanEnvironmentCommandFixture.cs" />
     <Compile Include="Commands\DeployReleaseCommandTestFixture.cs" />
     <Compile Include="Commands\DummyApiCommand.cs" />
     <Compile Include="Commands\ListEnvironmentsCommandFixture.cs" />

--- a/source/OctopusTools/Commands/CleanEnvironmentCommand.cs
+++ b/source/OctopusTools/Commands/CleanEnvironmentCommand.cs
@@ -30,7 +30,7 @@ namespace OctopusTools.Commands
         protected override void Execute()
         {
             if (string.IsNullOrWhiteSpace(environmentName)) throw new CommandException("Please specify an environment name using the parameter: --environment=XYZ");
-            if (status != MachineModelStatus.Unknown) throw new CommandException("Please specify status using the parameter: --status=Offline");
+            if (status == MachineModelStatus.Unknown) throw new CommandException("Please specify status using the parameter: --status=Offline");
 
             Log.Debug("Loading environment...");
             var environmentResource = Repository.Environments.FindByName(environmentName);

--- a/source/OctopusTools/Commands/CleanEnvironmentCommand.cs
+++ b/source/OctopusTools/Commands/CleanEnvironmentCommand.cs
@@ -47,7 +47,8 @@ namespace OctopusTools.Commands
 
                 foreach (var machine in machines)
                 {
-                    Log.InfoFormat(" - {0} {1} (ID: {2})", machine.Name, machine.Status, machine.Id);
+                    Log.InfoFormat("Deleting - {0} {1} (ID: {2})", machine.Name, machine.Status, machine.Id);
+                    Repository.Machines.Delete(machine);
                 }
             }
         }

--- a/source/OctopusTools/Commands/CleanEnvironmentCommand.cs
+++ b/source/OctopusTools/Commands/CleanEnvironmentCommand.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using log4net;
+using Octopus.Client.Model;
+using OctopusTools.Infrastructure;
+using OctopusTools.Util;
+
+namespace OctopusTools.Commands
+{
+    [Command("clean-environment", Description = "Cleans all Offline Machines from an Environment")]
+    public class CleanEnvironmentCommand : ApiCommand
+    {
+        string environmentName;
+        MachineModelStatus status = MachineModelStatus.Unknown;
+
+        public CleanEnvironmentCommand(IOctopusRepositoryFactory repositoryFactory, ILog log, IOctopusFileSystem fileSystem)
+            : base(repositoryFactory, log, fileSystem)
+        {
+            var options = Options.For("Cleanup");
+            options.Add("environment=", "Name of an environment to clean up.", v => environmentName = v);
+            options.Add("status=", "Status of Machines to clean up (Online, Offline, NeedsUpgrade, CalamariNeedsUpgrade, Disabled).", v =>
+            {
+                Enum.TryParse(v, true, out status);
+            });
+        }
+
+        protected override void Execute()
+        {
+            if (string.IsNullOrWhiteSpace(environmentName)) throw new CommandException("Please specify an environment name using the parameter: --environment=XYZ");
+            if (status != MachineModelStatus.Unknown) throw new CommandException("Please specify status using the parameter: --status=Offline");
+
+            Log.Debug("Loading environment...");
+            var environmentResource = Repository.Environments.FindByName(environmentName);
+
+            Log.Debug("Loading machines...");
+            var machines = Repository.Machines.FindMany(x =>
+            {
+                return x.Status == status && x.EnvironmentIds.Any(environmentId => environmentId == environmentResource.Id);
+            });
+
+            if (machines != null)
+            {
+                Log.Info("Machines: " + machines.Count);
+
+                foreach (var machine in machines)
+                {
+                    Log.InfoFormat(" - {0} {1} (ID: {2})", machine.Name, machine.Status, machine.Id);
+                }
+            }
+        }
+    }
+}

--- a/source/OctopusTools/OctopusTools.csproj
+++ b/source/OctopusTools/OctopusTools.csproj
@@ -102,6 +102,7 @@
     <Compile Include="..\Solution Items\VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="Commands\CleanEnvironmentCommand.cs" />
     <Compile Include="Commands\CreateEnvironmentCommand.cs" />
     <Compile Include="Commands\CreateProjectCommand.cs" />
     <Compile Include="Commands\DeploymentCommandBase.cs" />


### PR DESCRIPTION
New clean-environment Command will remove any machines from an environment which match a specified Status.  The command accepts the following parameters:

--environment="environment name"
--status=Offline